### PR TITLE
Fix tracks/genomes url rename

### DIFF
--- a/apollo_portal/tracks/admin.py
+++ b/apollo_portal/tracks/admin.py
@@ -15,7 +15,7 @@ class GenomeAdmin(admin.ModelAdmin):
     @admin.display(ordering="lab__name")
     def _lab_name(self, genome):
         return format_html(
-            '<a href="/admin/tracks/lab/{}/">{}</a>',
+            '<a href="/admin/genomes/lab/{}/">{}</a>',
             genome.lab.id,
             genome.lab.name,
         )
@@ -27,7 +27,7 @@ class TrackAdmin(admin.ModelAdmin):
     @admin.display(ordering="genome__name")
     def _genome_name(self, track):
         return format_html(
-            '<a href="/admin/tracks/genome/{}/">{}</a>',
+            '<a href="/admin/genomes/genome/{}/">{}</a>',
             track.genome.id,
             track.genome.name,
         )
@@ -35,7 +35,7 @@ class TrackAdmin(admin.ModelAdmin):
     @admin.display(ordering="lab__name")
     def _lab_name(self, track):
         return format_html(
-            '<a href="/admin/tracks/lab/{}/">{}</a>',
+            '<a href="/admin/genomes/lab/{}/">{}</a>',
             track.lab.id,
             track.lab.name,
         )

--- a/apollo_portal/tracks/templates/tracks/snippets/genome-cards.html
+++ b/apollo_portal/tracks/templates/tracks/snippets/genome-cards.html
@@ -8,14 +8,14 @@
   'strain', and 'condition'.
   e.g. hide_filters = ['lab']
 
-  filter_genomes_params: Object of GET params to pass to /tracks/api/genomes
+  filter_genomes_params: Object of GET params to pass to /genomes/api/genomes
   e.g. filter_genomes_params="{group: 'my group', labs: 'my Lab,your lab'}"
 -->
 
 {% load static %}
 
 <link rel="stylesheet" href="https://unpkg.com/vue-multiselect@2.1.6/dist/vue-multiselect.min.css">
-<link rel="stylesheet" href="{% static 'tracks/css/genome-cards.css' %}">
+<link rel="stylesheet" href="{% static 'genomes/css/genome-cards.css' %}">
 
 <!-- Use verbatim mode to prevent collision of Django and Vue template tags -->
 {% verbatim %}
@@ -573,7 +573,7 @@
           params = FILTER_GENOMES_PARAMS;
           urlParams = "?" + new URLSearchParams(params);
         }
-        return fetch('/tracks/api/genomes' + urlParams)
+        return fetch('/genomes/api/genomes' + urlParams)
           .catch(error => {
             alert(error);
           })
@@ -590,7 +590,7 @@
           });
       },
       fetchLab (name) {
-        return fetch(`/tracks/api/labs?labs=${name}`)
+        return fetch(`/genomes/api/labs?labs=${name}`)
           .catch(error => {
             alert(error);
           })

--- a/apollo_portal/tracks/templates/tracks/snippets/tracks-table.html
+++ b/apollo_portal/tracks/templates/tracks/snippets/tracks-table.html
@@ -8,14 +8,14 @@
   'strain', and 'condition'.
   e.g. hide_filters = ['lab']
 
-  filter_tracks_params: Object of GET params to pass to /tracks/api/tracks
+  filter_tracks_params: Object of GET params to pass to /genomes/api/tracks
   e.g. filter_tracks_params="{group: 'my group name', genome_id: genome_id <int>}"
 -->
 
 {% load static %}
 
 <link rel="stylesheet" href="https://unpkg.com/vue-multiselect@2.1.6/dist/vue-multiselect.min.css">
-<link rel="stylesheet" href="{% static 'tracks/css/genome-cards.css' %}">
+<link rel="stylesheet" href="{% static 'genomes/css/genome-cards.css' %}">
 
 <!-- Use verbatim mode to prevent collision of Django and Vue template tags -->
 {% verbatim %}
@@ -382,7 +382,7 @@
         const urlParams = params ?
           '?' + new URLSearchParams(params)
           : '';
-        return fetch('/tracks/api/tracks/' + urlParams)
+        return fetch('/genomes/api/tracks/' + urlParams)
           .catch(error => {
             alert(error);
           })
@@ -399,7 +399,7 @@
           });
       },
       fetchLab (name) {
-        return fetch(`/tracks/api/labs?labs=${name}`)
+        return fetch(`/genomes/api/labs?labs=${name}`)
           .catch(error => {
             alert(error);
           })

--- a/apollo_portal/tracks/templates/tracks/tracks.html
+++ b/apollo_portal/tracks/templates/tracks/tracks.html
@@ -72,7 +72,7 @@
   <hr class="my-3">
 
   <section class="my-5">
-    {% include 'tracks/snippets/tracks-table.html' %}
+    {% include 'genomes/snippets/tracks-table.html' %}
   </section>
 
 </div>

--- a/apollo_portal/tracks/views.py
+++ b/apollo_portal/tracks/views.py
@@ -6,12 +6,12 @@ from tracks.models import Genome
 
 def genomes(request):
     """Genomes list/filter view."""
-    return render(request, 'tracks/genomes.html')
+    return render(request, 'genomes/genomes.html')
 
 
 def tracks(request, genome_id):
     """Tracks table view."""
     genome = Genome.objects.get(id=genome_id)
-    return render(request, 'tracks/tracks.html', {
+    return render(request, 'genomes/tracks.html', {
         'genome': genome.as_json(),
     })


### PR DESCRIPTION
Some `tracks/` urls somehow escaped renaming to `genomes/`